### PR TITLE
feat: added moving_average_filter

### DIFF
--- a/src/utils/moving_average.cpp
+++ b/src/utils/moving_average.cpp
@@ -1,0 +1,25 @@
+#include "moving_average.h"
+
+namespace PlantMonitor {
+namespace Utils {   
+MovingAverage::MovingAverage(size_t size)
+    : m_size(size) {
+}
+void MovingAverage::addSample(float sample) {
+    if (m_samples.size() >= m_size) {
+        m_samples.erase(m_samples.begin());
+    }
+    m_samples.push_back(sample);
+}
+float MovingAverage::getAverage() const {
+    if (m_samples.empty()) {
+        return 0.0f;
+    }
+    float sum = std::accumulate(m_samples.begin(), m_samples.end(), 0.0f);
+    return sum / m_samples.size();
+}
+void MovingAverage::clear() {
+    m_samples.clear();
+}
+} // namespace Utils
+} // namespace PlantMonitor

--- a/src/utils/moving_average.h
+++ b/src/utils/moving_average.h
@@ -1,0 +1,46 @@
+#pragma once
+#include <vector>
+#include <numeric>
+
+/*!
+ * \file moving_average.h
+ * \brief Simple moving average filter utility
+ */
+
+
+namespace PlantMonitor {
+namespace Utils {
+/*!
+ * \class MovingAverage
+ * \brief Implements a simple moving average filter
+ */
+class MovingAverage {
+public:
+    /*! 
+     * \brief Constructor
+     * \param size Number of samples to average
+     */
+    explicit MovingAverage(size_t size);
+
+    /*!
+     * \brief Add a new sample to the filter
+     * \param sample New sample value
+     */
+    void addSample(float sample);
+
+    /*!
+     * \brief Get the current average value
+     * \return Average of the samples
+     */
+    float getAverage() const;
+
+    /*!
+     * \brief Clear all stored samples
+     */
+    void clear();
+private:
+    size_t m_size;                   //!< Number of samples to average
+    std::vector<float> m_samples; //!< Stored samples
+};
+} // namespace Utils
+} // namespace PlantMonitor


### PR DESCRIPTION
This pull request introduces a new utility for calculating moving averages, which will help smooth sensor data in the PlantMonitor project. The main changes involve the addition of a reusable `MovingAverage` class, complete with methods for adding samples, retrieving the average, and clearing stored data.

**New Moving Average Utility:**

* Added a new header file `moving_average.h` that defines the `MovingAverage` class, including documentation and method signatures for sample management and average calculation.
* Implemented the `MovingAverage` class in `moving_average.cpp`, providing logic for adding samples, calculating the average, and clearing samples.